### PR TITLE
Implement color convertion from/to Vec3 and HSL.

### DIFF
--- a/Flow.Launcher.Plugin.Color.csproj
+++ b/Flow.Launcher.Plugin.Color.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <ProjectGuid>{F35190AA-4758-4D9E-A193-E3BDF6AD3567}</ProjectGuid>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Flow.Launcher.Plugin.Color</RootNamespace>
@@ -10,6 +10,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -94,8 +95,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Flow.Launcher.Plugin" Version="2.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+    <PackageReference Include="Flow.Launcher.Plugin" Version="4.4.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Main.cs
+++ b/Main.cs
@@ -1,216 +1,324 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Windows;
 using System.Text.RegularExpressions;
-using System.Windows.Media;
 
-namespace Flow.Launcher.Plugin.Color
+namespace Flow.Launcher.Plugin.ColorsPlugin;
+
+public partial class ColorsPlugin : IPlugin, IPluginI18n
 {
-    public sealed class ColorsPlugin : IPlugin, IPluginI18n
+    const int ImageSize = 32;
+    const char Separator = ';';
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+    DirectoryInfo _cacheDir;
+    PluginInitContext _context;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+    [GeneratedRegex(@"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")]
+    private static partial Regex HexRegex();
+
+
+    [GeneratedRegex(@"^(?:(?:rgb)?(?:\s+|\s*\())?(\d{1,3}),\s?(\d{1,3}),\s?(\d{1,3})\)?$", RegexOptions.IgnoreCase)]
+    private static partial Regex RgbRegex();
+
+
+    [GeneratedRegex(@"^(?:(?:vec3)?(?:\s+|\s*\())?(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\)?$", RegexOptions.IgnoreCase)]
+    private static partial Regex Vec3Regex();
+
+
+    [GeneratedRegex(@"^(?:(?:hsl)?(?:\s+|\s*\())?(\d*\.?\d+)\s*,\s*(\d*\.?\d+)%\s*,\s*(\d*\.?\d+)%\)?$", RegexOptions.IgnoreCase)]
+    private static partial Regex HslRegex();
+
+    static string ToString(Color color)
     {
-        private const int IMG_SIZE = 32;
+        return $"{color.R}, {color.G}, {color.B}";
+    }
 
-        private DirectoryInfo ColorsDirectory { get; set; }
+    static string ToVec3String(Color color)
+    {
+        return string.Format("{0}, {1}, {2}",
+            (color.R / 255f).ToString("0.0###", CultureInfo.InvariantCulture),
+            (color.G / 255f).ToString("0.0###", CultureInfo.InvariantCulture),
+            (color.B / 255f).ToString("0.0###", CultureInfo.InvariantCulture));
+    }
 
-        private PluginInitContext context;
+    static string ToHslString(Color color)
+    {
+        float h = color.GetHue();
+        float s = color.GetSaturation() * 100;
+        float l = color.GetBrightness() * 100;
 
-        private readonly string colorCodeCleanRegex = @"(\s+|\(|\))";
+        return string.Format("{0:F1}, {1:F1}%, {2:F1}%",
+            h.ToString("0.#", CultureInfo.InvariantCulture),
+            s.ToString("0.#", CultureInfo.InvariantCulture),
+            l.ToString("0.#", CultureInfo.InvariantCulture));
+    }
 
-        public void Init(PluginInitContext context)
+    // C# port of https://gist.github.com/mjackson/5311256
+    static float HueToRgb(float p, float q, float t)
+    {
+        if (t < 0) t += 1f;
+        if (t > 1) t -= 1f;
+        if (t < 1f / 6f ) return p + (q - p) * 6f * t;
+        if (t < 1f / 2f) return q;
+        if (t < 2f / 3f) return p + (q - p) * (2f / 3f - t) * 6f;
+        return p;
+    }
+    static Color ToColor(float h, float s, float l)
+    {
+        h /= 360f;
+        s /= 100f;
+        l /= 100f;
+        float r, g, b;
+
+        if (s == 0)
         {
-            this.context = context;
-
-            var imageCacheDirectoryPath = Path.Combine(context.CurrentPluginMetadata.PluginDirectory, "CachedImages");
-
-            if (!Directory.Exists(imageCacheDirectoryPath))
-            {
-                ColorsDirectory = Directory.CreateDirectory(imageCacheDirectoryPath);
-            }
-            else
-            {
-                ColorsDirectory = new DirectoryInfo(imageCacheDirectoryPath);
-            }
+            r = g = b = l; // achromatic
+        }
+        else
+        {
+            float q = l < 0.5f ? l * (1f + s) : l + s - l * s;
+            float p = 2 * l - q;
+            r = HueToRgb(p, q, h + 1f / 3f);
+            g = HueToRgb(p, q, h);
+            b = HueToRgb(p, q, h - 1f / 3f);
         }
 
-        public List<Result> Query(Query query)
-        {
-            var search = query.Search;
+        return Color.FromArgb(255, (int)MathF.Round(r * 255f),
+                                   (int)MathF.Round(g * 255f),
+                                   (int)MathF.Round(b * 255f));
+    }
 
-            if (string.IsNullOrEmpty(search))
-                return new List<Result> {
-                    new Result
+    static string GetImageFileName(Color color)
+    {
+        return ColorTranslator.ToHtml(color) + ".png";
+    }
+
+    string? GetCachedImagePath(Color color)
+    {
+        return _cacheDir.GetFiles(GetImageFileName(color), SearchOption.TopDirectoryOnly).FirstOrDefault()?.FullName;
+    }
+
+    string CreateImageCache(Color color)
+    {
+        using Bitmap bitmap = new(ImageSize, ImageSize);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        graphics.Clear(color);
+
+        string path = Path.Combine(_cacheDir.FullName, GetImageFileName(color));
+        bitmap.Save(path, ImageFormat.Png);
+
+        return path;
+    }
+
+    string GetColorImagePath(Color color)
+    {
+        if (GetCachedImagePath(color) is string cachePath)
+        {
+            return cachePath;
+        }
+
+        return CreateImageCache(color);
+    }
+
+    bool IsGlobalQuery()
+    {
+        return _context.CurrentPluginMetadata.ActionKeyword == "*";
+    }
+
+    public void Init(PluginInitContext context)
+    {
+        _context = context;
+
+        string path = Path.Combine(_context.CurrentPluginMetadata.PluginDirectory, "cache");
+        if (!Directory.Exists(path))
+        {
+            _cacheDir = Directory.CreateDirectory(path);
+        }
+        else
+        {
+            _cacheDir = new DirectoryInfo(path);
+        }
+
+        foreach (FileInfo file in _cacheDir.EnumerateFiles())
+        {
+            file.Delete();
+        }
+    }
+
+    public List<Result>? Query(Query query)
+    {
+        if (string.IsNullOrEmpty(query.Search))
+        {
+            return IsGlobalQuery() ? null : new List<Result>(1)
+            {
+                new()
+                {
+                    Title = _context.API.GetTranslation("flowlauncher_plugin_color_plugin_multi_code_format"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_color_plugin_multi_code_format_suggestion"),
+                    IcoPath = _context.CurrentPluginMetadata.IcoPath,
+                    Action = _ =>
                     {
-                        Title = context.API.GetTranslation("flowlauncher_plugin_color_plugin_multi_code_format"),
-                        SubTitle = context.API.GetTranslation("flowlauncher_plugin_color_plugin_multi_code_format_suggestion"),
-                        IcoPath = context.CurrentPluginMetadata.IcoPath,
-                        Action = _ =>
-                        {
-                            Clipboard.SetDataObject("99,197,34;(39,0,152)");
-                            return true;
-                        }
+                        _context.API.CopyToClipboard("99,197,34;(39,0,152)");
+                        return true;
+                    }
+                }
+            };
+        }
+
+        string[] inputs = query.Search.Split(Separator, StringSplitOptions.TrimEntries);
+        List<Result> results = new(inputs.Length * 4);
+        foreach (string input in inputs)
+        {
+            Color color = Color.Black;
+            bool isSet = false;
+
+            {
+                if (HexRegex().IsMatch(input))
+                {
+                    color = ColorTranslator.FromHtml(input);
+                    isSet = true;
+                }
+            }
+
+            if (!isSet)
+            {
+                Match rgbMatch = RgbRegex().Match(input);
+                if (rgbMatch.Success)
+                {
+                    byte r = byte.Parse(rgbMatch.Groups[1].Value);
+                    byte g = byte.Parse(rgbMatch.Groups[2].Value);
+                    byte b = byte.Parse(rgbMatch.Groups[3].Value);
+                    color = Color.FromArgb(255, r, g, b);
+                    isSet = true;
+                }
+            }
+
+            if (!isSet)
+            {
+                Match vec3Match = Vec3Regex().Match(input);
+                if (vec3Match.Success)
+                {
+                    float r = float.Parse(vec3Match.Groups[1].Value, CultureInfo.InvariantCulture);
+                    float g = float.Parse(vec3Match.Groups[2].Value, CultureInfo.InvariantCulture);
+                    float b = float.Parse(vec3Match.Groups[3].Value, CultureInfo.InvariantCulture);
+                    if (r <= 1 && g <= 1 && b <= 1)
+                    {
+                        color = Color.FromArgb(255, (int)MathF.Round(r * 255f),
+                                                    (int)MathF.Round(g * 255f),
+                                                    (int)MathF.Round(b * 255f));
+
+                        isSet = true;
+                    }
+                }
+            }
+
+            if (!isSet)
+            {
+                Match hslMatch = HslRegex().Match(input);
+                if (hslMatch.Success)
+                {
+                    float h = float.Parse(hslMatch.Groups[1].Value, CultureInfo.InvariantCulture);
+                    float s = float.Parse(hslMatch.Groups[2].Value, CultureInfo.InvariantCulture);
+                    float l = float.Parse(hslMatch.Groups[3].Value, CultureInfo.InvariantCulture);
+                    if (h <= 360 && s <= 100 && l <= 100)
+                    {
+                        color = ToColor(h, s, l);
+                        isSet = true;
+                    }
+                }
+            }
+
+            if (!isSet)
+            {
+                return IsGlobalQuery() ? null : new List<Result>(1)
+                {
+                    new()
+                    {
+                        Title = _context.API.GetTranslation("flowlauncher_plugin_color_plugin_name"),
+                        SubTitle = _context.API.GetTranslation("flowlauncher_plugin_color_plugin_conversion_error"),
+                        IcoPath = _context.CurrentPluginMetadata.IcoPath,
                     }
                 };
+            }
 
-            var rawList = search.Split(';');
-
-            var results = new List<Result>();
-
-            foreach (var raw in rawList)
-            {
-
-                // Standardise format since rgb code typed in could be 99,197,34 or (39,0,152)
-                var colorCode = Regex.Replace(raw, colorCodeCleanRegex, "");
-
-                var rgbRegex = new Regex(@"^(\d{1,3}),\s?(\d{1,3}),\s?(\d{1,3})$");
-                var hexRegex = new Regex(@"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$");
-                var isRgb = rgbRegex.IsMatch(colorCode);
-                var isHex = hexRegex.IsMatch(colorCode);
-
-                if (!isRgb && !isHex)
-                    return new List<Result>();
-
-                if (isRgb)
+            string imgPath = GetColorImagePath(color);
+            string hexStr = ColorTranslator.ToHtml(color);
+            results.Add(
+                new()
                 {
-                    var rgbValues = colorCode.Split(',').Select(int.Parse).ToList();
-                    if (rgbValues.Any(val => val > 255))
-                        return new List<Result>();
-                }
-
-                try
-                {
-                    var createdColorImagePath = string.Empty;
-
-                    var cached = FindFileImage(colorCode);
-                    if (cached == null)
+                    Title = hexStr,
+                    SubTitle = "hex",
+                    IcoPath = imgPath,
+                    Action = _ =>
                     {
-                        createdColorImagePath = CreateCacheImage(colorCode);
-
-                        results.Add(
-                            new Result
-                            {
-                                Title = isRgb ? string.Format("({0})", colorCode) : colorCode,
-                                SubTitle = isRgb ? "RGB" : "HEX",
-                                IcoPath = createdColorImagePath,
-                                Action = _ =>
-                                {
-                                    Clipboard.SetDataObject(colorCode);
-                                    return true;
-                                }
-                            });
-
+                        _context.API.CopyToClipboard(hexStr);
+                        return true;
                     }
-                    else
+                }
+            );
+
+            string rgbStr = ToString(color);
+            results.Add(
+                new()
+                {
+                    Title = rgbStr,
+                    SubTitle = "rgb",
+                    IcoPath = imgPath,
+                    Action = _ =>
                     {
-                        createdColorImagePath = cached.FullName;
-
-                        results.Add(
-                            new Result
-                            {
-                                Title = isRgb ? string.Format("({0})", colorCode) : colorCode,
-                                SubTitle = isRgb ? "RGB" : "HEX",
-                                IcoPath = createdColorImagePath,
-                                Action = _ =>
-                                {
-                                    Clipboard.SetDataObject(colorCode);
-                                    return true;
-                                }
-                            });
+                        _context.API.CopyToClipboard(rgbStr);
+                        return true;
                     }
-
-                    // Reverse conversion
-                    var conversion = isRgb ? RgbToHex(colorCode, rgbRegex) : HexToRgb(colorCode);
-
-                    results.Add(
-                        new Result
-                        {
-                            Title = conversion,
-                            SubTitle = isRgb ? "HEX" : "RGB",
-                            IcoPath = createdColorImagePath,
-                            Action = _ =>
-                            {
-                                Clipboard.SetDataObject(conversion);
-                                return true;
-                            }
-                        });
                 }
-                catch (Exception e)
+            );
+
+            string vec3Str = ToVec3String(color);
+            results.Add(
+                new()
                 {
-                    context.API.ShowMsgError(context.API.GetTranslation("flowlauncher_plugin_color_plugin_name"),
-                        context.API.GetTranslation("flowlauncher_plugin_color_plugin_conversion_error"));
-
-                    context.API.LogException("Query", "Colors plugin failed to convert user's input", e);
-
-                    return new List<Result>();
+                    Title = vec3Str,
+                    SubTitle = "vec3",
+                    IcoPath = imgPath,
+                    Action = _ =>
+                    {
+                        _context.API.CopyToClipboard(vec3Str);
+                        return true;
+                    }
                 }
-            }
+            );
 
-            return results;
-        }
-
-        public FileInfo FindFileImage(string name)
-        {
-            var file = string.Format("{0}.png", name);
-
-            // shouldnt have multiple files of the same name
-            return ColorsDirectory.GetFiles(file, SearchOption.TopDirectoryOnly).FirstOrDefault();
-        }
-
-        private string CreateCacheImage(string name)
-        {
-            using (var bitmap = new Bitmap(IMG_SIZE, IMG_SIZE))
-            using (var graphics = Graphics.FromImage(bitmap))
-            {
-                var colorCode = name;
-                var rgbRegex = new Regex(@"^(\d{1,3}),\s?(\d{1,3}),\s?(\d{1,3})$");
-                var isRgb = rgbRegex.IsMatch(colorCode);
-                if (isRgb)
+            string hslStr = ToHslString(color);
+            results.Add(
+                new()
                 {
-                    colorCode = RgbToHex(colorCode, rgbRegex); // Convert RGB to hex
+                    Title = hslStr,
+                    SubTitle = "hsl",
+                    IcoPath = imgPath,
+                    Action = _ =>
+                    {
+                        _context.API.CopyToClipboard(hslStr);
+                        return true;
+                    }
                 }
-                var color = ColorTranslator.FromHtml(colorCode);
-                graphics.Clear(color);
-
-
-                var path = Path.Combine(ColorsDirectory.FullName, name + ".png");
-                bitmap.Save(path, ImageFormat.Png);
-                return path;
-            }
+            );
         }
 
-        private string HexToRgb(string hex)
-        {
-            var color = ColorTranslator.FromHtml(hex);
-            return $"({color.R},{color.G},{color.B})";
-        }
+        return results;
+    }
 
-        private string RgbToHex(string rgb, Regex rgbRegex)
-        {
-            var color = new List<string>();
-            // match multiple RGB input?
-            foreach (Match match in Regex.Matches(rgb, rgbRegex.ToString(), RegexOptions.IgnoreCase))
-            {
-                var r = int.Parse(match.Groups[1].Value);
-                var g = int.Parse(match.Groups[2].Value);
-                var b = int.Parse(match.Groups[3].Value);
-                var c = System.Drawing.Color.FromArgb(255, r, g, b);
-                color.Add(ColorTranslator.ToHtml(c));
-            }
+    public string GetTranslatedPluginTitle()
+    {
+        return _context.API.GetTranslation("flowlauncher_plugin_color_plugin_name");
+    }
 
-            return color.First();
-        }
-
-        public string GetTranslatedPluginTitle()
-        {
-            return context.API.GetTranslation("flowlauncher_plugin_color_plugin_name");
-        }
-
-        public string GetTranslatedPluginDescription()
-        {
-            return context.API.GetTranslation("flowlauncher_plugin_color_plugin_description");
-        }
+    public string GetTranslatedPluginDescription()
+    {
+        return _context.API.GetTranslation("flowlauncher_plugin_color_plugin_description");
     }
 }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,26 @@ The Color plugin was part of Flow Launcher's default plugins and is now a standa
 
 For a history of commits for Color plugin itself, please see Flow Launcher's commit history.
 
-The HexRgb plugin is created by VladimÌr Antoö (@vladimirantos) and ported over into Color plugin.
+The HexRgb plugin is created by Vladim√≠r Anto≈° (@vladimirantos) and ported over into Color plugin.
 
-This plugin is for previewing color in hex or rgb. From flow type `#d948a7` or `217,72,167` or `99,197,34;(39,0,152)`
+This plugin is for previewing and converting colors between hex, rgb, vec3 and hsl.
+
+## Preview:
+### Examples of valid inputs:
+#d948a7
+
+217,72,167
+
+0.8509804, 0.28235295, 0.654902
+
+320.7, 65.6%, 56.7%
+
+### Multiple inputs in a single query:
+#d948a7 ; 217,72,167 ; 0.8509804, 0.28235295, 0.654902 ; 320.7, 65.6%, 56.7%
+
+Whitespace and paranthesis are ignored.
+
+Inputs can be prefixed with rgb, vec3 and hsl to avoid ambiguity.
+
+![image](https://github.com/user-attachments/assets/85092512-0b13-44e8-85c9-e38328ba7be5)
+

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Colors",
   "Description": "Provides HEX and RGB color preview.",
   "Author": "qianlifeng, Vladimir Antos, bluray",
-  "Version": "2.0.2",
+  "Version": "3.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher.Plugin.Color",
   "ExecuteFileName": "Flow.Launcher.Plugin.Color.dll",


### PR DESCRIPTION
Fixes https://github.com/Flow-Launcher/Flow.Launcher.Plugin.Color/issues/6

## Major changes
Implement color convertion from/to Vec3 and HSL.
Migrate to .NET 7
Bump dependencies.

## Misc
Clear cache on startup.
Use System.Drawing.Color object instead of strings for passing colors around.
Added a preview screenshot in readme.
Convertion error and hint are only shown when this plugin is the only one to respond to the query.

![image](https://github.com/user-attachments/assets/85092512-0b13-44e8-85c9-e38328ba7be5)